### PR TITLE
CakePHP 3.6 support and PHPStan (task #8244)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,6 @@ end_of_line = crlf
 [*.yml]
 indent_style = space
 indent_size = 2
+
+[*.twig]
+insert_final_newline = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,52 @@
+# Define the line ending behavior of the different file extensions
+# Set default behaviour, in case users don't have core.autocrlf set.
+* text=auto
+* text eol=lf
+
+# Explicitly declare text files we want to always be normalized and converted
+# to native line endings on checkout.
+.htaccess text
+*.css text diff=css
+*.ctp text diff=php
+*.default text
+*.html text diff=html
+*.ini text
+*.js text
+*.md text
+*.php text diff=php
+*.po text
+*.properties text
+*.sql text
+*.svg text
+*.txt text
+*.xml text
+*.yml text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.bat eol=crlf
+
+# Declare files that will always have LF line endings on checkout.
+*.pem eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+composer binary
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary
+*.mo binary
+*.pdf binary
+*.phar binary
+
+# Web fonts are binary
+*.otf binary
+*.eot binary
+*.ttf binary
+*.woff binary
+*.woff2 binary
+
+# Treat zip files as binary
+*.7z binary
+*.bz2 binary
+*.gz binary
+*.zip binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,41 @@
+# Project specific files #
+##########################
 build/
 vendor/
+cghooks.lock
+
 composer.lock
 config/Migrations/schema-dump-default.lock
 config/Migrations/schema-dump-test.lock
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db
+
+# Tool specific files #
+#######################
+# vim
+*~
+*.swp
+*.swo
+# sublime text & textmate
+*.sublime-*
+*.stTheme.cache
+*.tmlanguage.cache
+*.tmPreferences.cache
+# Eclipse
+.settings/*
+# JetBrains, aka PHPStorm, IntelliJ IDEA
+.idea/*
+# NetBeans
+nbproject/*
+# Visual Studio Code
+.vscode
+# Sass preprocessor
+.sass-cache/

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,6 +1,7 @@
 linters:
   phpcs:
     standard: CakePHP
-    extensions: '.php,.ctp'
+    extensions: 'php,ctp'
+    exclude: 'Generic.Commenting.Todo'
 files:
-  ignore: ['config/*', 'tests/*']
+    ignore: ['webroot/plugins/*']

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,8 @@
-#This Travis config template file was taken from https://github.com/FriendsOfCake/travis
-sudo: true
-dist: trusty
-
 language: php
 
-php:
-  - 7.1
-  - 7.2
-  - nightly
+dist: trusty
+
+sudo: false
 
 cache:
   directories:
@@ -21,25 +16,39 @@ env:
 
 matrix:
   fast_finish: true
+
   allow_failures:
+    - php: 7.3
     - php: nightly
+
+  include:
+    - php: 7.1
+      env: PHPCS=1 COVERAGE=1 PHPSTAN=0
+    - php: 7.2
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+    - php: 7.3
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+    - php: nightly
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
 
 install:
   - composer validate --strict
   - composer install --no-interaction --no-progress --no-suggest
-  - mkdir -p build/logs
+  - mkdir -p build/test-coverage build/test-results
 
 before_script:
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE IF NOT EXISTS cakephp_test DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'; fi"
 
 script:
-  - vendor/bin/phpcs
-  - if [ $TRAVIS_PHP_VERSION != "7.1" ]; then vendor/bin/phpunit --no-coverage; else vendor/bin/phpunit; fi
+  - if [[ $PHPCS = 1 ]]; then ./vendor/bin/phpcs; fi
+  - if [[ $COVERAGE = 0 ]]; then ./vendor/bin/phpunit --no-coverage; fi
+  - if [[ $COVERAGE = 1 ]]; then ./vendor/bin/phpunit; fi
+  - if [[ $PHPSTAN = 1 ]]; then ./vendor/bin/phpstan analyse; fi
 
 after_success:
   - curl -s https://codecov.io/bash > /tmp/codecov.sh
   - chmod +x /tmp/codecov.sh
-  - /tmp/codecov.sh -s build/logs
+  - /tmp/codecov.sh -s build/test-results
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,13 @@ matrix:
 
   include:
     - php: 7.1
-      env: PHPCS=1 COVERAGE=1 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=1 PHPSTAN=1
     - php: 7.2
-      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=1
     - php: 7.3
-      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=1
     - php: nightly
-      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=1
 
 install:
   - composer validate --strict

--- a/composer.json
+++ b/composer.json
@@ -1,35 +1,58 @@
 {
     "name": "qobo/cakephp-comments",
     "description": "Comments plugin for CakePHP",
+    "keywords": ["cakephp", "comments"],
     "type": "cakephp-plugin",
     "license": "MIT",
+    "homepage": "https://www.qobo.biz",
     "authors": [
         {
             "name": "Qobo Ltd",
-            "email": "info@qobo.biz",
+            "email": "support@qobo.biz",
             "homepage": "https://www.qobo.biz",
             "role": "Developer"
         }
     ],
+    "support": {
+        "issues": "https://github.com/QoboLtd/cakephp-comments/issues",
+        "source": "https://github.com/QoboLtd/cakephp-comments"
+    },
+    "config": {
+        "sort-packages": true,
+        "optimize-autoloader": true
+    },
     "require": {
-        "qobo/cakephp-utils": "^9.0"
+        "qobo/cakephp-utils": "^10.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
-        "cakephp/cakephp-codesniffer": "^3.0"
+        "qobo/cakephp-composer-dev": "^v1.0"
     },
     "autoload": {
         "psr-4": {
-            "Qobo\\Comments\\": "src",
-            "Qobo\\Comments\\Test\\Fixture\\": "tests\\Fixture",
-            "CakeDC\\Users\\Test\\Fixture\\": "tests"
+            "Qobo\\Comments\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Qobo\\Comments\\Test\\": "tests",
-            "CakeDC\\Users\\Test\\": "./vendor/cakedc/users/tests",
-            "Cake\\Test\\": "./vendor/cakephp/cakephp/tests"
+            "Qobo\\Comments\\Test\\": "tests/",
+            "CakeDC\\Users\\Test\\": "vendor/cakedc/users/tests/",
+            "Cake\\Test\\": "vendor/cakephp/cakephp/tests/"
         }
-    }
+    },
+    "scripts": {
+        "test": [
+            "phpcs",
+            "phpunit --no-coverage"
+        ],
+        "test-coverage": [
+            "phpcs",
+            "phpunit"
+        ],
+        "post-autoload-dump": "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump"
+    },
+    "scripts-descriptions": {
+        "test": "Runs phpcs and phpunit without coverage",
+        "test-coverage": "Runs phpcs and phpunit with coverage enabled"
+    },
+    "prefer-stable": true
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,16 +9,15 @@
     <description>PHP CodeSniffer Configuration</description>
 
     <!-- Coding standard to use -->
-    <rule ref="./vendor/cakephp/cakephp-codesniffer/CakePHP" />
+    <rule ref="./vendor/cakephp/cakephp-codesniffer/CakePHP">
+        <exclude name="Generic.Commenting.Todo" />
+    </rule>
 
     <!-- Do not fail on warnings -->
     <config name="ignore_warnings_on_exit" value="1" />
 
     <!-- Assume UTF-8 -->
     <config name="encoding" value="UTF-8" />
-
-    <!-- Extensions to check -->
-    <arg name="extensions" value="php,inc,ctp,js,css" />
 
     <!-- Use colors -->
     <arg name="colors" />
@@ -29,5 +28,12 @@
     <!-- Files and directories to check -->
     <file>./src/</file>
     <file>./tests/</file>
+    <file>./config/</file>
     <file>./webroot/</file>
+
+    <!-- Exclude patterns -->
+    <exclude-pattern>config/Migrations/*</exclude-pattern>
+    <exclude-pattern>config/Seeds/*</exclude-pattern>
+    <exclude-pattern>webroot/plugins/*</exclude-pattern>
+    <exclude-pattern>*\.min\.(css|js)</exclude-pattern>
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,14 @@
+parameters:
+    level: 7
+    paths:
+        - src
+        - tests
+        - webroot
+    autoload_files:
+        - tests/bootstrap.php
+    earlyTerminatingMethodCalls:
+        Cake\Console\Shell:
+            - abort
+includes:
+    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
+    - vendor/timeweb/phpstan-enum/extension.neon

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,31 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-	colors="true"
-	processIsolation="false"
-	stopOnFailure="false"
-	syntaxCheck="false"
-	bootstrap="./tests/bootstrap.php"
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    bootstrap="./tests/bootstrap.php"
     verbose="true"
-	>
-	<php>
-		<ini name="memory_limit" value="-1"/>
-		<ini name="apc.enable_cli" value="1"/>
-	</php>
-
-	<filter>
-		<whitelist>
-            <directory suffix=".php">./src/</directory>
-            <directory suffix=".php">./webroot/</directory>
-		</whitelist>
-	</filter>
+    >
+    <php>
+        <ini name="memory_limit" value="-1"/>
+        <ini name="apc.enable_cli" value="1"/>
+    </php>
 
     <logging>
-		<log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
-		<log type="coverage-html" target="build/coverage"/>
-		<log type="coverage-clover" target="build/logs/clover.xml"/>
-		<log type="coverage-crap4j" target="build/logs/crap4j.xml"/>
-		<log type="junit" target="build/logs/junit.xml"/>
+        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
+        <log type="coverage-html" target="build/test-coverage"/>
+        <log type="coverage-clover" target="build/test-results/clover.xml"/>
+        <log type="coverage-crap4j" target="build/test-results/crap4j.xml"/>
+        <log type="junit" target="build/test-results/junit.xml"/>
     </logging>
+
+    <!-- Add any additional test suites you want to run here -->
+    <testsuites>
+        <testsuite name="comments">
+            <directory>tests/TestCase</directory>
+        </testsuite>
+    </testsuites>
 
     <!-- Setup a listener for fixtures -->
     <listeners>
@@ -38,11 +37,11 @@
         </listener>
     </listeners>
 
-    <!-- Add any additional test suites you want to run here -->
-    <testsuites>
-        <testsuite name="Plugin Test Suite">
-            <directory>./tests/TestCase</directory>
-        </testsuite>
-    </testsuites>
-
+    <!-- Ignore vendor tests in code coverage reports -->
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./src/</directory>
+            <directory suffix=".php">./webroot/</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/Controller/CommentsController.php
+++ b/src/Controller/CommentsController.php
@@ -76,7 +76,7 @@ class CommentsController extends AppController
         $this->set('success', $success);
         $success ?
             $this->set('data', $comment->get('id')) :
-            $this->set('error', sprintf('Failed to save comment: %s', json_encode($comment->errors())));
+            $this->set('error', sprintf('Failed to save comment: %s', json_encode($comment->getErrors())));
 
         $this->set('_serialize', ['success', 'data', 'error']);
     }

--- a/src/Controller/CommentsController.php
+++ b/src/Controller/CommentsController.php
@@ -37,19 +37,22 @@ class CommentsController extends AppController
     /**
      * Index method.
      *
-     * @return \Cake\Http\Response|void
+     * @return \Cake\Http\Response|void|null
      */
     public function index()
     {
         $this->request->allowMethod(['get']);
 
+        /**
+         * @var \Cake\ORM\Query $data
+         */
         $data = $this->Comments->find('all')
             ->where([
                 'related_model' => $this->request->getParam('pass.0'),
                 'related_id' => $this->request->getParam('pass.1')
             ])
-            ->contain('Author')
-            ->all();
+            ->contain('Author');
+        $data = $data->all();
 
         $this->set('success', true);
         $this->set('data', $data);
@@ -59,17 +62,21 @@ class CommentsController extends AppController
     /**
      * Add method.
      *
-     * @return \Cake\Http\Response|void Redirects on successful add, renders view otherwise
+     * @return \Cake\Http\Response|void|null Redirects on successful add, renders view otherwise
      */
     public function add()
     {
         $this->request->allowMethod(['post']);
 
+        $data = $this->request->getData();
+        $data = is_array($data) ? $data : [];
+        /**
+         * @var array $data
+         */
+        $data = array_merge($data, ['user_id' => $this->Auth->user('id')]);
+
         $comment = $this->Comments->newEntity();
-        $comment = $this->Comments->patchEntity($comment, array_merge(
-            $this->request->getData(),
-            ['user_id' => $this->Auth->user('id')]
-        ));
+        $comment = $this->Comments->patchEntity($comment, $data);
 
         $success = (bool)$this->Comments->save($comment);
 
@@ -85,10 +92,9 @@ class CommentsController extends AppController
      * Delete method.
      *
      * @param string $id Comment id
-     * @return \Cake\Http\Response|void Redirects to index
-     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found
+     * @return \Cake\Http\Response|void|null Redirects to index
      */
-    public function delete($id)
+    public function delete(string $id)
     {
         $this->request->allowMethod(['post', 'delete']);
 
@@ -101,7 +107,7 @@ class CommentsController extends AppController
             return;
         }
 
-        $success = (bool)$this->Comments->delete($comment);
+        $success = $this->Comments->delete($comment);
 
         $this->set('success', $success);
         $success ? $this->set('data', []) : $this->set('error', 'Failed to delete comment');

--- a/tests/App/Application.php
+++ b/tests/App/Application.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link      https://cakephp.org CakePHP(tm) Project
+ * @since     3.3.0
+ * @license   https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Qobo\Comments\Test\App;
+
+use Cake\Core\Configure;
+use Cake\Error\Middleware\ErrorHandlerMiddleware;
+use Cake\Http\BaseApplication;
+use Cake\Routing\Middleware\AssetMiddleware;
+use Cake\Routing\Middleware\RoutingMiddleware;
+
+/**
+ * Application setup class.
+ *
+ * This defines the bootstrapping logic and middleware layers you
+ * want to use in your application.
+ */
+class Application extends BaseApplication
+{
+    /**
+     * Setup the middleware queue your application will use.
+     *
+     * @param \Cake\Http\MiddlewareQueue $middlewareQueue The middleware queue to setup.
+     * @return \Cake\Http\MiddlewareQueue The updated middleware queue.
+     */
+    public function middleware($middlewareQueue)
+    {
+        $middlewareQueue
+            // Catch any exceptions in the lower layers,
+            // and make an error page/response
+            ->add(ErrorHandlerMiddleware::class)
+
+            // Handle plugin/theme assets like CakePHP normally does.
+            ->add(AssetMiddleware::class)
+
+            // Add routing middleware.
+            ->add(new RoutingMiddleware($this));
+
+        return $middlewareQueue;
+    }
+}

--- a/tests/App/Controller/AppController.php
+++ b/tests/App/Controller/AppController.php
@@ -5,5 +5,16 @@ use \Cake\Controller\Controller;
 
 class AppController extends Controller
 {
-    public $components = ['Auth', 'Flash', 'RequestHandler'];
+    public function initialize()
+    {
+        parent::initialize();
+        $this->loadComponent('Auth', [
+            'authenticate' => ['Form']
+        ]);
+
+        $this->loadComponent('Flash');
+        $this->loadComponent('RequestHandler', [
+            'enableBeforeRedirect' => false,
+        ]);
+    }
 }

--- a/tests/App/Controller/UsersController.php
+++ b/tests/App/Controller/UsersController.php
@@ -1,14 +1,16 @@
 <?php
 namespace Qobo\Comments\Test\App\Controller;
 
-use \Cake\Controller\Controller;
+use Cake\Controller\Controller;
 
 class UsersController extends Controller
 {
     /**
      * Simple users login action
+     *
+     * @return void
      */
-    public function login()
+    public function login(): void
     {
     }
 }

--- a/tests/TestCase/Controller/CommentsControllerTest.php
+++ b/tests/TestCase/Controller/CommentsControllerTest.php
@@ -6,6 +6,8 @@ use Cake\TestSuite\IntegrationTestCase;
 
 /**
  * Qobo\Comments\Test\App\Controller\CommentsController Test Case
+ *
+ * @property \Qobo\Comments\Model\Table\CommentsTable $Comments
  */
 class CommentsControllerTest extends IntegrationTestCase
 {
@@ -18,7 +20,11 @@ class CommentsControllerTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        $this->Comments = TableRegistry::getTableLocator()->get('Qobo/Comments.Comments');
+        /**
+         * @var \Qobo\Comments\Model\Table\CommentsTable $table
+         */
+        $table = TableRegistry::getTableLocator()->get('Qobo/Comments.Comments');
+        $this->Comments = $table;
 
         $this->configRequest([
             'headers' => [
@@ -36,14 +42,14 @@ class CommentsControllerTest extends IntegrationTestCase
         parent::tearDown();
     }
 
-    public function testIndexUnauthenticated()
+    public function testIndexUnauthenticated(): void
     {
         $this->get('/comments/comments/index/Articles/00000000-0000-0000-0000-000000000001');
 
         $this->assertResponseCode(403);
     }
 
-    public function testIndex()
+    public function testIndex(): void
     {
         $this->session(['Auth.User.id' => '00000000-0000-0000-0000-000000000004']);
 
@@ -58,14 +64,14 @@ class CommentsControllerTest extends IntegrationTestCase
         $this->assertNotEmpty($response->data);
     }
 
-    public function testAddUnauthenticated()
+    public function testAddUnauthenticated(): void
     {
         $this->post('/comments/comments/add');
 
         $this->assertResponseCode(403);
     }
 
-    public function testAdd()
+    public function testAdd(): void
     {
         $this->session(['Auth.User.id' => '00000000-0000-0000-0000-000000000004']);
 
@@ -75,7 +81,7 @@ class CommentsControllerTest extends IntegrationTestCase
             'related_id' => '00000000-0000-0000-0000-000000000001'
         ];
 
-        $this->post('/comments/comments/add', json_encode($data));
+        $this->post('/comments/comments/add', $data);
 
         $this->assertResponseCode(200);
         $this->assertJson($this->_getBodyAsString());
@@ -89,7 +95,7 @@ class CommentsControllerTest extends IntegrationTestCase
         $this->assertEmpty(array_diff($data, $entity->toArray()));
     }
 
-    public function testAddInvalidData()
+    public function testAddInvalidData(): void
     {
         $this->session(['Auth.User.id' => '00000000-0000-0000-0000-000000000004']);
 
@@ -98,7 +104,7 @@ class CommentsControllerTest extends IntegrationTestCase
             'related_id' => true
         ];
 
-        $this->post('/comments/comments/add', json_encode($data));
+        $this->post('/comments/comments/add', $data);
 
         $this->assertResponseCode(200);
         $this->assertJson($this->_getBodyAsString());
@@ -112,19 +118,23 @@ class CommentsControllerTest extends IntegrationTestCase
         $this->assertContains('related_id', $response->error);
     }
 
-    public function testDeleteUnauthenticated()
+    public function testDeleteUnauthenticated(): void
     {
         $this->delete('/comments/comments/delete/00000000-0000-0000-0000-000000000001');
 
         $this->assertResponseCode(403);
     }
 
-    public function testDelete()
+    public function testDelete(): void
     {
         $this->session(['Auth.User.id' => '00000000-0000-0000-0000-000000000004']);
 
         $id = '00000000-0000-0000-0000-000000000001';
-        $query = $this->Comments->find('all')->where([$this->Comments->getPrimaryKey() => $id]);
+        /**
+         * @var string $primaryKey
+         */
+        $primaryKey = $this->Comments->getPrimaryKey();
+        $query = $this->Comments->find('all')->where([$primaryKey => $id]);
 
         $this->assertFalse($query->isEmpty());
 
@@ -133,14 +143,18 @@ class CommentsControllerTest extends IntegrationTestCase
         $this->assertResponseCode(200);
         $this->assertJson($this->_getBodyAsString());
 
-        $query = $this->Comments->find('all')->where([$this->Comments->getPrimaryKey() => $id]);
+        /**
+         * @var string $primaryKey
+         */
+        $primaryKey = $this->Comments->getPrimaryKey();
+        $query = $this->Comments->find('all')->where([$primaryKey => $id]);
         $response = json_decode($this->_getBodyAsString());
 
         $this->assertTrue($response->success);
         $this->assertTrue($query->isEmpty());
     }
 
-    public function testDeleteFromOtherUser()
+    public function testDeleteFromOtherUser(): void
     {
         $this->session(['Auth.User.id' => '00000000-0000-0000-0000-000000000004']);
 
@@ -151,7 +165,11 @@ class CommentsControllerTest extends IntegrationTestCase
         $this->assertResponseCode(200);
         $this->assertJson($this->_getBodyAsString());
 
-        $query = $this->Comments->find('all')->where([$this->Comments->getPrimaryKey() => $id]);
+        /**
+         * @var string $primaryKey
+         */
+        $primaryKey = $this->Comments->getPrimaryKey();
+        $query = $this->Comments->find('all')->where([$primaryKey => $id]);
         $response = json_decode($this->_getBodyAsString());
 
         $this->assertFalse($response->success);

--- a/tests/TestCase/Model/Table/CommentsTableTest.php
+++ b/tests/TestCase/Model/Table/CommentsTableTest.php
@@ -36,7 +36,11 @@ class CommentsTableTest extends TestCase
     {
         parent::setUp();
 
-        $this->Comments = TableRegistry::getTableLocator()->get('Qobo/Comments.Comments');
+        /**
+         * @var \Qobo\Comments\Model\Table\CommentsTable $table
+         */
+        $table = TableRegistry::getTableLocator()->get('Qobo/Comments.Comments');
+        $this->Comments = $table;
     }
 
     /**
@@ -56,7 +60,7 @@ class CommentsTableTest extends TestCase
      *
      * @return void
      */
-    public function testInitialize()
+    public function testInitialize(): void
     {
         $this->assertInstanceOf(CommentsTable::class, $this->Comments);
 
@@ -76,7 +80,7 @@ class CommentsTableTest extends TestCase
      *
      * @return void
      */
-    public function testValidationDefault()
+    public function testValidationDefault(): void
     {
         $this->assertInstanceOf(Validator::class, $this->Comments->validationDefault(new Validator()));
     }
@@ -86,12 +90,12 @@ class CommentsTableTest extends TestCase
      *
      * @return void
      */
-    public function testBuildRules()
+    public function testBuildRules(): void
     {
         $this->assertInstanceOf(RulesChecker::class, $this->Comments->buildRules(new RulesChecker()));
     }
 
-    public function testSave()
+    public function testSave(): void
     {
         $data = [
             'content' => 'Hello World',

--- a/tests/TestCase/Model/Table/CommentsTableTest.php
+++ b/tests/TestCase/Model/Table/CommentsTableTest.php
@@ -68,7 +68,7 @@ class CommentsTableTest extends TestCase
         $this->assertTrue($this->Comments->hasBehavior('Tree'));
         $this->assertTrue($this->Comments->hasBehavior('Trash'));
 
-        $this->assertInstanceOf(BelongsTo::class, $this->Comments->association('Author'));
+        $this->assertInstanceOf(BelongsTo::class, $this->Comments->getAssociation('Author'));
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,37 +1,34 @@
 <?php
-// @codingStandardsIgnoreFile
-
 use Cake\Core\Configure;
 use Cake\Filesystem\Folder;
 
 $pluginName = 'Comments';
 if (empty($pluginName)) {
-    throw new \Exception("Plugin name is not configured");
+    throw new \RuntimeException("Plugin name is not configured");
 }
 
-$findRoot = function () {
-    $root = dirname(__DIR__);
-    if (is_dir($root . '/vendor/cakephp/cakephp')) {
-        return $root;
-    }
-
-    $root = dirname(dirname(__DIR__));
-    if (is_dir($root . '/vendor/cakephp/cakephp')) {
-        return $root;
-    }
-
-    $root = dirname(dirname(dirname(__DIR__)));
-    if (is_dir($root . '/vendor/cakephp/cakephp')) {
-        return $root;
-    }
-
-    throw new \Exception("Failed to find CakePHP");
+/*
+ * Test suite bootstrap
+ *
+ * This function is used to find the location of CakePHP whether CakePHP
+ * has been installed as a dependency of the plugin, or the plugin is itself
+ * installed as a dependency of an application.
+ */
+$findRoot = function ($root) {
+    do {
+        $lastRoot = $root;
+        $root = dirname($root);
+        if (is_dir($root . '/vendor/cakephp/cakephp')) {
+            return $root;
+        }
+    } while ($root !== $lastRoot);
+    throw new \RuntimeException("Failed to find CakePHP");
 };
 
 if (!defined('DS')) {
     define('DS', DIRECTORY_SEPARATOR);
 }
-define('ROOT', $findRoot());
+define('ROOT', $findRoot(__FILE__));
 define('APP_DIR', 'App');
 define('WEBROOT_DIR', 'webroot');
 define('APP', ROOT . '/tests/App/');
@@ -83,7 +80,7 @@ $cache = [
     ]
 ];
 
-Cake\Cache\Cache::config($cache);
+Cake\Cache\Cache::setConfig($cache);
 Cake\Core\Configure::write('Session', [
     'defaults' => 'php'
 ]);
@@ -93,13 +90,13 @@ if (!getenv('db_dsn')) {
     putenv('db_dsn=sqlite:///:memory:');
 }
 
-Cake\Datasource\ConnectionManager::config('default', [
+Cake\Datasource\ConnectionManager::setConfig('default', [
     'url' => getenv('db_dsn'),
     'quoteIdentifiers' => true,
     'timezone' => 'UTC'
 ]);
 
-Cake\Datasource\ConnectionManager::config('test', [
+Cake\Datasource\ConnectionManager::setConfig('test', [
     'url' => getenv('db_dsn'),
     'quoteIdentifiers' => true,
     'timezone' => 'UTC'
@@ -108,10 +105,7 @@ Cake\Datasource\ConnectionManager::config('test', [
 // Alias AppController to the test App
 class_alias('Qobo\\' . $pluginName . '\Test\App\Controller\AppController', 'App\Controller\AppController');
 // If plugin has routes.php/bootstrap.php then load them, otherwise don't.
-$loadPluginRoutes = file_exists(dirname(__FILE__) . DS . 'config' . DS . 'routes.php');
-$loadPluginBootstrap = file_exists(dirname(__FILE__) . DS . 'config' . DS . 'bootstrap.php');
+$loadPluginRoutes = file_exists(ROOT . DS . 'config' . DS . 'routes.php');
+$loadPluginBootstrap = file_exists(ROOT . DS . 'config' . DS . 'bootstrap.php');
 Cake\Core\Plugin::load('Qobo/' . $pluginName, ['path' => ROOT . DS, 'autoload' => true, 'routes' => $loadPluginRoutes, 'bootstrap' => $loadPluginBootstrap]);
 Cake\Core\Plugin::load('CakeDC/Users', ['routes' => true, 'bootstrap' => true]);
-
-Cake\Routing\DispatcherFactory::add('Routing');
-Cake\Routing\DispatcherFactory::add('ControllerFactory');

--- a/tests/config/routes.php
+++ b/tests/config/routes.php
@@ -5,10 +5,4 @@ use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Routing\Router;
 
-/**
- * Load all plugin routes.  See the Plugin documentation on
- * how to customize the loading of plugin routes.
- */
-Plugin::routes();
-
 Router::connect('/users/login', ['controller' => 'Users', 'action' => 'login']);


### PR DESCRIPTION
* Updated to [cakephp-plugin-template v5.2.1](https://github.com/QoboLtd/cakephp-plugin-template/releases/tag/v5.2.1).
* Updated `composer.json`.
* Fixed all of deprecated errors for CakePHP 3.6.
* Fixed all of PHPStan issues.
* Enabled PHPStan on TravisCI