### PR TITLE
Drop cakephp-utils (task #12216)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     ],
     "require": {
         "cakedc/users": "^8.0",
+        "cakephp/cakephp": "^3.5 <3.7",
         "muffin/trash": "^2.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
     ],
     "require": {
         "cakedc/users": "^8.0",
-        "cakephp/cakephp": "^3.5 <3.7",
         "muffin/trash": "^2.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         }
     ],
     "require": {
-        "qobo/cakephp-utils": "^13.0"
+        "cakedc/users": "^8.0",
+        "muffin/trash": "^2.1"
     },
     "require-dev": {
         "qobo/cakephp-composer-dev": "^v1.0"


### PR DESCRIPTION
This PR removes the dependency on `qobo/cakephp-utils` plugin.