### PR TITLE
Support for CakePHP v3.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,15 +21,9 @@
         "sort-packages": true,
         "optimize-autoloader": true
     },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/QoboLtd/cakephp-file-storage.git"
-        }
-    ],
     "require": {
         "cakedc/users": "^8.0",
-        "cakephp/cakephp": "^3.5 <3.7",
+        "cakephp/cakephp": "^3.8",
         "muffin/trash": "^2.1"
     },
     "require-dev": {
@@ -62,6 +56,5 @@
         "test": "Runs phpcs and phpunit without coverage",
         "test-coverage": "Runs phpcs and phpunit with coverage enabled"
     },
-    "prefer-stable": true,
-    "minimum-stability": "dev"
+    "prefer-stable": true
 }

--- a/src/Model/Table/CommentsTable.php
+++ b/src/Model/Table/CommentsTable.php
@@ -58,17 +58,17 @@ class CommentsTable extends Table
     {
         $validator
             ->uuid('id')
-            ->allowEmpty('id', 'create');
+            ->allowEmptyString('id', null, 'create');
 
         $validator
             ->scalar('content')
             ->requirePresence('content', 'create')
-            ->notEmpty('content');
+            ->notEmptyString('content');
 
         $validator
             ->uuid('user_id')
             ->requirePresence('user_id', 'create')
-            ->notEmpty('user_id');
+            ->notEmptyString('user_id');
 
         $validator
             ->scalar('related_model')
@@ -79,11 +79,11 @@ class CommentsTable extends Table
         $validator
             ->uuid('related_id')
             ->requirePresence('related_id', 'create')
-            ->notEmpty('related_id');
+            ->notEmptyString('related_id');
 
         $validator
             ->dateTime('trashed')
-            ->allowEmpty('trashed');
+            ->allowEmptyDateTime('trashed');
 
         return $validator;
     }

--- a/tests/TestCase/Controller/CommentsControllerTest.php
+++ b/tests/TestCase/Controller/CommentsControllerTest.php
@@ -12,8 +12,8 @@ use Cake\TestSuite\IntegrationTestCase;
 class CommentsControllerTest extends IntegrationTestCase
 {
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
-        'plugin.Qobo/Comments.comments',
+        'plugin.CakeDC/Users.Users',
+        'plugin.Qobo/Comments.Comments',
     ];
 
     public function setUp()

--- a/tests/TestCase/Controller/CommentsControllerTest.php
+++ b/tests/TestCase/Controller/CommentsControllerTest.php
@@ -2,15 +2,18 @@
 namespace Qobo\Comments\Test\TestCase\Controller;
 
 use Cake\ORM\TableRegistry;
-use Cake\TestSuite\IntegrationTestCase;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
 
 /**
  * Qobo\Comments\Test\App\Controller\CommentsController Test Case
  *
  * @property \Qobo\Comments\Model\Table\CommentsTable $Comments
  */
-class CommentsControllerTest extends IntegrationTestCase
+class CommentsControllerTest extends TestCase
 {
+    use IntegrationTestTrait;
+
     public $fixtures = [
         'plugin.CakeDC/Users.Users',
         'plugin.Qobo/Comments.Comments',

--- a/tests/TestCase/Model/Table/CommentsTableTest.php
+++ b/tests/TestCase/Model/Table/CommentsTableTest.php
@@ -16,8 +16,8 @@ use Qobo\Comments\Model\Table\CommentsTable;
 class CommentsTableTest extends TestCase
 {
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
-        'plugin.Qobo/Comments.comments',
+        'plugin.CakeDC/Users.Users',
+        'plugin.Qobo/Comments.Comments',
     ];
 
     /**


### PR DESCRIPTION
This PR defines v3.8 as the minimum CakePHP version acceptable and fixes most of the deprecation warnings.
